### PR TITLE
Add note regarding explicit prop declaration requirement

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -696,6 +696,7 @@ Vue.component('my-checkbox', {
     event: 'change'
   },
   props: {
+    checked: Boolean,
     // this allows using the `value` prop for a different purpose
     value: String
   },
@@ -716,6 +717,8 @@ The above will be equivalent to:
   value="some value">
 </my-checkbox>
 ```
+
+<p class="tip">Note that you still have to declare the `checked` prop explicitly.</p>
 
 ### Non Parent-Child Communication
 


### PR DESCRIPTION
When customizing the `v-model` behaviour, the new prop name has to be explicitly defined in the props list. This adds a note about it to the docs.

Regarding https://github.com/vuejs/vue/issues/5834